### PR TITLE
fixed import for SpecifierSet and Specifier from packaging

### DIFF
--- a/src/pymodaq_plugin_manager/validate.py
+++ b/src/pymodaq_plugin_manager/validate.py
@@ -4,7 +4,8 @@ from typing import List, Union
 from hashlib import sha256
 from packaging import version
 from packaging.version import Version
-from packaging.requirements import Requirement, SpecifierSet, Specifier
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet, Specifier
 import pkg_resources
 from jsonschema import validate
 import json


### PR DESCRIPTION
Following the email on the mailing list and the issue #112 on the pymodaq repository, I modified the imports. 
This runs OK on my linux computer with python 3.8.15 and the last pymodaq release, the dashboard starts.