### PR TITLE
Removed argument passed to subprocess creation. 

### DIFF
--- a/src/pymodaq_plugin_manager/manager.py
+++ b/src/pymodaq_plugin_manager/manager.py
@@ -346,7 +346,7 @@ class PluginManager(QtCore.QObject):
         try:
             self.print_info(' '.join(command))
 
-            with subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True, shell=True) as sp:
+            with subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True) as sp:
                 while True:
                     self.print_info(sp.stdout.readline())
                     return_code = sp.poll()


### PR DESCRIPTION
This fixes a blocking call in the `do_subprocess()` function on my system and allows the plugin installation to proceed.