### PR TITLE
Script and weekly github action to check plugins compatibility

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,53 @@
+name: Compatibility verification between PyMoDAQ and plugins
+
+on:
+  schedule:
+    - cron: '0 15 * * 0'  # Runs at 3pm UTC on Sunday
+  workflow_dispatch:
+
+jobs:
+  check-compatibility:
+    strategy:
+      fail-fast: false
+      matrix:
+        pymodaq-version: ["4.4.x", "5.0.x_dev"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' 
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-cursor0 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1
+          export QT_DEBUG_PLUGINS=1
+
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install hatch pyqt5
+          pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}
+
+      - name: Run script
+        run: |
+          source venv/bin/activate
+          python scripts/compatibility-checker.py "git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}"
+
+      - name: Upload reports if failed
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-reports-${{ matrix.pymodaq-version }}
+          path: reports
+
+      - name: Check version
+        if: always()
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          source venv/bin/activate
+          pip list

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+chardet
 distlib
 jsonschema
 pytablewriter

--- a/scripts/compatibility-checker.py
+++ b/scripts/compatibility-checker.py
@@ -58,7 +58,8 @@ class PyMoDAQPlugin:
         bool:
             True if the plugin could be installed or is already installed, False otherwise    
         '''
-        command = [sys.executable, '-m', 'pip', 'install', f'{self._name}=={self._version}']
+        package = f'{self._name}=={self._version}' if self._version else f'{self._name}'
+        command = [sys.executable, '-m', 'pip', 'install', package]
         if args.pymodaq:
             command.append(args.pymodaq)
             
@@ -117,6 +118,7 @@ class PyMoDAQPlugin:
 def parse_args():
     parser = argparse.ArgumentParser(description="Detect incompatibilities between a PyMoDAQ version and the released plugins")
     parser.add_argument("-r", type=Path, default=Path("reports/"), dest="reports_path", help="Path to the reports folder (default: reports/)")
+    parser.add_argument("-p", type=str, default=None, dest="plugin", help="plugin to check (instead of the complete list)")
     parser.add_argument(nargs="?", type=str, default="", dest="pymodaq", help="Installation source of the PyMoDAQ package (default: empty string)")
 
     return parser.parse_args()
@@ -137,9 +139,13 @@ def main():
     code = 0
     args.reports_path.mkdir(parents=True, exist_ok=True)
 
-    
-    plugin_list = get_pypi_plugins()
-    
+
+    if args.plugin:
+        plugin_list = [{"plugin-name" : args.plugin, "version" : None}]
+    else:
+        plugin_list = get_pypi_plugins()
+
+
     for p in plugin_list:
         plugin = PyMoDAQPlugin(p['plugin-name'], p['version'])
         if plugin.install():

--- a/scripts/compatibility-checker.py
+++ b/scripts/compatibility-checker.py
@@ -1,0 +1,154 @@
+import chardet
+import logging
+import ast
+import sys
+from pathlib import Path
+import subprocess
+import importlib
+import argparse
+
+
+from pymodaq_plugin_manager.utils import get_pymodaq_version
+from pymodaq_plugin_manager.validate import get_plugins, get_pypi_pymodaq, get_package_metadata, get_pypi_plugins
+
+def _detect_encoding(filename):
+    '''
+       Detect encoding of a file 
+
+    Parameters
+    ----------
+    filename: str
+        the file for which the encoding is to be detected
+    Returns
+    -------
+    str:
+        The encoding
+    '''
+    with open(filename, "rb") as f:
+        raw = f.read()
+        return chardet.detect(raw)['encoding']
+
+class PyMoDAQPlugin:
+    '''
+        A simple class to represent a PyMoDAQ plugin, from a `pip install`
+        point of view
+    '''
+    def __init__(self, name, version):
+        self._name = name
+        self._version = version
+        self._install_result = None
+
+    @property
+    def name(self):
+        return self._name
+    
+    @property
+    def version(self):
+        return self._version
+    
+    def _get_location(self):
+        return importlib.util.find_spec(self._name).submodule_search_locations[0]
+
+    def install(self) -> bool:
+        '''
+           Try to install this plugin using pip
+
+        Returns
+        -------
+        bool:
+            True if the plugin could be installed or is already installed, False otherwise    
+        '''
+        command = [sys.executable, '-m', 'pip', 'install', f'{self._name}=={self._version}']
+        if args.pymodaq:
+            command.append(args.pymodaq)
+            
+        self._install_result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        return self._install_result.returncode == 0
+
+    def _save_report(self, name, stream):
+        with open(args.reports_path / name, 'w') as f:
+            f.write(stream)
+
+    def save_install_report(self):
+        self._save_report(f'install_report_{self._name}_{self._version}.txt', self._install_result.stdout)
+    
+    def save_import_report(self):
+        self._save_report(f'import_report_{self._name}_{self._version}.txt', '\n'.join(self._failed_imports + [''])) 
+
+    def all_imports_valid(self) -> bool:
+        '''
+            Check if this plugin imports are all valid
+
+        Returns
+        -------
+        bool:
+            True if all imports are valid (no import failed), False otherwise    
+        '''
+        self._failed_imports = []
+        install_path = self._get_location()
+
+        for filename in Path(install_path).glob('**/*.py'):
+            with open(filename, 'r', encoding=_detect_encoding(filename)) as f:
+                tree = ast.parse(f.read(), filename=filename)
+                for node in tree.body:
+                    try:
+                        if (isinstance(node, ast.ImportFrom) and 'pymodaq' in node.module) \
+                        or (isinstance(node, ast.Import) and any('pymodaq' in name.name for name in node.names)):
+                            for name in node.names:
+                                try:
+                                    if isinstance(node, ast.ImportFrom):
+                                        import_code = f'from {node.module} import {name.name}'
+                                        getattr(importlib.import_module(node.module), name.name)                            
+                                    elif isinstance(node, ast.Import):
+                                        import_code = f'import {name.name}'
+                                        if name.asname:
+                                            import_code += f' as {name.asname}'
+                                        importlib.import_module(node.module)
+                                
+                                except (ImportError, ModuleNotFoundError):
+                                    self._failed_imports.append(f'"{import_code}" in {filename} ({node.lineno})') 
+                                except Exception as e:
+                                    print(f'Unknown: {e}')
+                    except TypeError as te:
+                        pass
+        
+        return len(self._failed_imports) == 0
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Detect incompatibilities between a PyMoDAQ version and the released plugins")
+    parser.add_argument("-r", type=Path, default=Path("reports/"), dest="reports_path", help="Path to the reports folder (default: reports/)")
+    parser.add_argument(nargs="?", type=str, default="", dest="pymodaq", help="Installation source of the PyMoDAQ package (default: empty string)")
+
+    return parser.parse_args()
+
+def main():
+    '''
+        The script use `get_pypi_plugins` function to get a list of all PyMoDAQ plugins.
+        Then it tries to install each plugin. If it fails it write a report (in `args.reports_path`)
+        Otherwise, it tries to execute all its import clauses containing "pymodaq". If at least 
+        one import fail, a report is made (with relevant information).
+
+        Finally, if something failed, the script signal it by returning with an exit code of 1.
+    '''
+    global args
+
+    args = parse_args()
+    
+    code = 0
+    args.reports_path.mkdir(parents=True, exist_ok=True)
+
+    
+    plugin_list = get_pypi_plugins()
+    
+    for p in plugin_list:
+        plugin = PyMoDAQPlugin(p['plugin-name'], p['version'])
+        if plugin.install():
+            if not plugin.all_imports_valid():
+                plugin.save_import_report()
+                code = 1
+        else:
+            plugin.save_install_report()
+            code = 1
+    sys.exit(code)
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR provides a script (`compatibility/checker.py`) to check for the compatibility of `import` statements between a plugin and a PyMoDAQ version:

```bash
python scripts/compatibility-checker.py [pymodaq_source_of_installation] [-p plugin]
```

`pymodaq_source_of_installation` being an optional argument to tell the script which version to pymodaq to install:

- It may be a git link, a "pymodaq==version" string, or any valid source of installation for `pip install`
- It may be empty, in this case:
   - PyMoDAQ is already installed and the script will use the installed version
   - PyMoDAQ is not installed, so it will get installed when dependencies will be resolved by the first installed plugin

There is another optional argument `-p plugin` to only check for a specific `plugin` 

Reports will be generated in the `reports` folder.

There is also a weekly github action to run the script using the last sources of PyMoDAQ from branches `4.4.x` and `5.0.x_dev` . (But it sometimes fail to not default to the last version available on `pip`) but provides reports in `.zip` artifact files.