### PR TITLE
Fix for compatibility checker & possibility to chose where to save a report when used as a library

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,4 +1,4 @@
-name: Compatibility verification between PyMoDAQ and plugins
+name: Compatibility verification between PyMoDAQ (latest) and plugins
 
 on:
   schedule:
@@ -9,8 +9,6 @@ jobs:
   check-compatibility:
     strategy:
       fail-fast: false
-      matrix:
-        pymodaq-version: ["4.4.x", "5.0.x_dev"]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -31,18 +29,18 @@ jobs:
           source venv/bin/activate
           python -m pip install --upgrade pip
           pip install hatch pyqt5
-          pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}
-
+          pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git
+          
       - name: Run script
         run: |
           source venv/bin/activate
-          python src/pymodaq_plugin_manager/compatibility_checker.py "git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}"
+          python src/pymodaq_plugin_manager/compatibility_checker.py "git+https://github.com/PyMoDAQ/PyMoDAQ.git"
 
       - name: Upload reports if failed
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: failure-reports-${{ matrix.pymodaq-version }}
+          name: failure-reports
           path: reports
 
       - name: Check version

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -41,8 +41,12 @@ jobs:
       - name: Run script
         run: |
           source venv/bin/activate
-          python src/pymodaq_plugin_manager/compatibility_checker.py "git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}"
-
+          if [[ "${{ matrix.pymodaq-version }}" = "latest" ]]; then
+            pymodaq="git+https://github.com/PyMoDAQ/PyMoDAQ.git"
+          else
+            pymodaq="git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}"
+          fi
+            python src/pymodaq_plugin_manager/compatibility_checker.py "${pymodaq}"
       - name: Upload reports if failed
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,4 +1,4 @@
-name: Compatibility verification between PyMoDAQ (latest) and plugins
+name: Compatibility verification between PyMoDAQ and plugins
 
 on:
   schedule:
@@ -9,6 +9,8 @@ jobs:
   check-compatibility:
     strategy:
       fail-fast: false
+      matrix:
+        pymodaq-version: ["4.4.x", "latest"] # latest is not a real branch / version name 
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -29,18 +31,22 @@ jobs:
           source venv/bin/activate
           python -m pip install --upgrade pip
           pip install hatch pyqt5
-          pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git
+          if [[ "${{ matrix.pymodaq-version }}" = "latest" ]]; then
+            pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git
+          else
+            pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}
+          fi
           
       - name: Run script
         run: |
           source venv/bin/activate
-          python src/pymodaq_plugin_manager/compatibility_checker.py "git+https://github.com/PyMoDAQ/PyMoDAQ.git"
+          python src/pymodaq_plugin_manager/compatibility_checker.py "git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}"
 
       - name: Upload reports if failed
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: failure-reports
+          name: failure-reports-${{ matrix.pymodaq-version }}
           path: reports
 
       - name: Check version

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -36,6 +36,7 @@ jobs:
           else
             pip install git+https://github.com/PyMoDAQ/PyMoDAQ.git@${{ matrix.pymodaq-version }}
           fi
+          pip install -e .
           
       - name: Run script
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 ]
 
 dependencies = [
-    'pymodaq',
     'distlib',
     'jsonschema',
     'pytablewriter',

--- a/src/pymodaq_plugin_manager/__init__.py
+++ b/src/pymodaq_plugin_manager/__init__.py
@@ -1,4 +1,4 @@
-from pymodaq_utils.utils import get_version
+from importlib import metadata
 
-__version__ = get_version('pymodaq_plugin_manager')
+__version__ = metadata.version('pymodaq_plugin_manager')
 

--- a/src/pymodaq_plugin_manager/compatibility_checker.py
+++ b/src/pymodaq_plugin_manager/compatibility_checker.py
@@ -66,15 +66,19 @@ class PyMoDAQPlugin:
         self._install_result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         return self._install_result.returncode == 0
 
-    def _save_report(self, name, stream):
-        with open(args.reports_path / name, 'w') as f:
+    def _save_report(self, name, stream, path = None):
+        if not path:
+            path = args.reports_path
+        else:
+            path = Path(path) 
+        with open(path / name, 'w') as f:
             f.write(stream)
 
-    def save_install_report(self):
-        self._save_report(f'install_report_{self._name}_{self._version}.txt', self._install_result.stdout)
+    def save_install_report(self, path = None):
+        self._save_report(f'install_report_{self._name}_{self._version}.txt', self._install_result.stdout, path=path)
     
-    def save_import_report(self):
-        self._save_report(f'import_report_{self._name}_{self._version}.txt', '\n'.join(self._failed_imports + [''])) 
+    def save_import_report(self, path = None):
+        self._save_report(f'import_report_{self._name}_{self._version}.txt', '\n'.join(self._failed_imports + ['']), path=path) 
 
     def all_imports_valid(self) -> bool:
         '''


### PR DESCRIPTION
Fixes #25 by re-implementing the way to get version.

It fixes the github action to check compatibility. Now it checks with branch 4.4.x and the latest main one.
 
Also, `PyMoDAQPlugin.save_xxx_report` methods now accept a parameter to chose where to save the report.


(A new release should be done when accepting the PR.)