### PR TITLE
Patch/package name with hyphens

### DIFF
--- a/src/pymodaq_plugin_manager/manager.py
+++ b/src/pymodaq_plugin_manager/manager.py
@@ -75,9 +75,9 @@ class FilterProxy(QtCore.QSortFilterProxyModel):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.textRegExp = QtCore.QRegExp()
-        self.textRegExp.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
-        self.textRegExp.setPatternSyntax(QtCore.QRegExp.Wildcard)
+        self.textRegExp = QtCore.QRegularExpression()
+        self.textRegExp.setPatternOptions(QtCore.QRegularExpression.CaseInsensitiveOption)
+        #self.textRegExp.setPatternSyntax(QtCore.QRegularExpression.Wildcard)
 
     def filterAcceptsRow(self, sourcerow, parent_index):
         plugin_index = self.sourceModel().index(sourcerow, 0, parent_index)
@@ -110,7 +110,7 @@ class PluginFetcher(QtCore.QObject):
 
     def fetch_plugins(self):
         plugins = get_plugins(False, pymodaq_version=get_pymodaq_version(),
-                                             print_method=self.print_method)
+                              print_method=self.print_method)
         self.plugins_signal.emit(plugins)
 
 


### PR DESCRIPTION
some pymodaq plugins are written with underscores and some others are written with hyphen (-) . I think the change came from going from setup.py to pyproject using hatch. The published package now doen't convert underscores to hyphens!