### PR TITLE
Bugfix/crash and checkbox

### DIFF
--- a/src/pymodaq_plugin_manager/manager.py
+++ b/src/pymodaq_plugin_manager/manager.py
@@ -64,7 +64,7 @@ class TableModel(TableModel):
                     return False
             if role == Qt.CheckStateRole:
                 if index.column() == 0:
-                    self._selected[index.row()] = value == Qt.Checked
+                    self._selected[index.row()] = value == Qt.Checked.value
                     self.dataChanged.emit(index, index, [role])
                     return True
         return False

--- a/src/pymodaq_plugin_manager/manager.py
+++ b/src/pymodaq_plugin_manager/manager.py
@@ -103,14 +103,14 @@ class FilterProxy(QtCore.QSortFilterProxyModel):
 class PluginFetcher(QtCore.QObject):
 
     plugins_signal = QtCore.Signal(tuple)
+    print_signal = QtCore.Signal(str)
 
-    def __init__(self, print_method=logger.info):
+    def __init__(self):
         super().__init__()
-        self.print_method = print_method
 
     def fetch_plugins(self):
         plugins = get_plugins(False, pymodaq_version=get_pymodaq_version(),
-                              print_method=self.print_method)
+                              print_method=self.print_signal.emit)
         self.plugins_signal.emit(plugins)
 
 
@@ -141,8 +141,9 @@ class PluginManager(QtCore.QObject):
         self.enable_ui(False)
 
         self.plugin_thread = QtCore.QThread()
-        plugin_fetcher = PluginFetcher(self.print_info)
+        plugin_fetcher = PluginFetcher()
         plugin_fetcher.plugins_signal.connect(self.setup_models)
+        plugin_fetcher.print_signal.connect(self.print_info)
         plugin_fetcher.moveToThread(self.plugin_thread)
         self.plugin_thread.plugin_fetcher = plugin_fetcher
         self.plugin_thread.started.connect(plugin_fetcher.fetch_plugins)
@@ -432,7 +433,7 @@ def main():
     win.setCentralWidget(widget)
     win.show()
     prog = PluginManager(widget, standalone=True)
-    sys.exit(app.exec_())
+    app.exec()
 
 
 if __name__ == '__main__':

--- a/src/pymodaq_plugin_manager/manager.py
+++ b/src/pymodaq_plugin_manager/manager.py
@@ -3,7 +3,7 @@ from packaging import version as version_mod
 import sys
 import subprocess
 
-
+from enum import Enum
 import numpy as np
 from qtpy import QtWidgets, QtCore
 from qtpy.QtCore import Qt, Slot, Signal
@@ -64,7 +64,11 @@ class TableModel(TableModel):
                     return False
             if role == Qt.CheckStateRole:
                 if index.column() == 0:
-                    self._selected[index.row()] = value == Qt.Checked.value
+                    # Qt.Checked is an enum in qt6 but an int in qt5
+                    # it can be directly compared in qt5 but getting
+                    # the value attribute is needed with qt6
+                    qt_checked =  Qt.Checked.value if  isinstance(Qt.Checked, Enum) else Qt.Checked
+                    self._selected[index.row()] = value == qt_checked
                     self.dataChanged.emit(index, index, [role])
                     return True
         return False

--- a/src/pymodaq_plugin_manager/utils.py
+++ b/src/pymodaq_plugin_manager/utils.py
@@ -69,7 +69,7 @@ class MyStyle(QtWidgets.QProxyStyle):
         we're hovering over.  This may not always work depending on global
         style - for instance I think it won't work on OSX.
         """
-        if element == self.PE_IndicatorItemViewItemDrop and not option.rect.isNull():
+        if element == self.PrimitiveElement.PE_IndicatorItemViewItemDrop and not option.rect.isNull():
             option_new = QtWidgets.QStyleOption(option)
             option_new.rect.setLeft(0)
             if widget:


### PR DESCRIPTION
Solves (maybe) [PyMoDAQ#587](https://github.com/PyMoDAQ/PyMoDAQ/issues/587)
Solves #29

When using qt6 it was not possible to select any plugin for installation because with qt6 `Qt.Checked` became an Enum, so we need to use its value attribute when needed. As in qt5 'Qt.Checked' returns an int, there is an ugly check but it should works.

Also while trying to debug this issue, I got a lot of segmentation faults. After investigation, it was because information about the fetched plugins were printed on the interface from a thread. [It seems modifying UI is only allowed from the main thread.](https://forum.qt.io/topic/145653/segmentation-fault-while-working-with-qthreads/2?_=1744812921876)  I tinkered a bit to make it work with a signal.

