### PR TITLE
Filtering plugins in plugin_manager

### DIFF
--- a/src/pymodaq_plugin_manager/manager.py
+++ b/src/pymodaq_plugin_manager/manager.py
@@ -33,7 +33,7 @@ class TableModel(TableModel):
     def flags(self, index):
         f = super().flags(index)
         if index.column() == 0:
-            f |= Qt.ItemIsUserCheckable
+            f |= Qt.ItemFlag.ItemIsUserCheckable            
         return f
 
     def data(self, index, role=Qt.ItemDataRole.DisplayRole):
@@ -79,18 +79,20 @@ class FilterProxy(QtCore.QSortFilterProxyModel):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.text = ''
+
     def filterAcceptsRow(self, sourcerow, parent_index):
         plugin_index = self.sourceModel().index(sourcerow, 0, parent_index)
+        parent = self.parent()
         try:
             plugin = self.sourceModel().plugins[plugin_index.row()]
             match = self.text == ''
             if not (match or not plugin):
-                if self.parent().filter_name_cb.isChecked():
+                if hasattr(parent, "filter_name_cb") and parent.filter_name_cb.isChecked():
                     match = match or self.text in plugin['plugin-name'].lower()
                     match = match or self.text in plugin['display-name'].lower()
-                if self.parent().filter_description_cb.isChecked():
+                if hasattr(parent, "filter_description_cb") and parent.filter_description_cb.isChecked():
                     match = match or self.text in plugin['description'].lower()
-                if self.parent().filter_instrument_cb.isChecked():                        
+                if hasattr(parent, "filter_instrument_cb") and parent.filter_instrument_cb.isChecked():                        
                     for plug in plugin['instruments']:
                         match = match | any(self.text in p.lower() for p in plugin['instruments'][plug])
             return match


### PR DESCRIPTION
Small PR related to the behavior of the plugin manager

Some preliminary comments
- The way the filter is being used does not require at all RegExp syntax and I am not sure that we are interested in going in that direction. Overall, this complexifies the syntax for not much reason.

- The filter checks all the information (name/description/instrument) to test if a plugin should be displayed in the list. This does not feel necessary as a standard behavior (in particular if the plugin's description are outdated.)
As a small example, by typing `thorlabs`
![image](https://github.com/user-attachments/assets/81318081-ae4b-46f6-8ab7-04fcbde4a527)
One gets access to plugins not related to it. In fact, it is because the thorlabs word appear in a url in the description of the plugin (which is not seen by the user).
In fact, if one would type `thor`, all the plugins would be accepted as you can find `authors ` in all the plugins' description.

What this PR does:

- it simplifies the syntax by only testing str instead of using regexp making it less prone to error for standard use

- it adds some QCheckBox to extend the filter settings, in general one would only need to filter by name which is now the standard use. With the example above, now we only see Thorlabs as expected.

![image](https://github.com/user-attachments/assets/e8ecd018-9438-4dd8-9912-5bc36dd36d71)

- it updates the use of Qt.Something to use the full path which makes it easier to read, e.g `Qt.DisplayRole` becomes `Qt.ItemDataRole.DisplayRole` with qtpy. In practice, this helps avoiding possible conflicts between different Qt version:
